### PR TITLE
Change FFMPEG scaling behavior.

### DIFF
--- a/src/pages/api/videos/upload.ts
+++ b/src/pages/api/videos/upload.ts
@@ -93,8 +93,8 @@ upload.post(async (req: MulterRequest, res) => {
       'h264',
       '-acodec',
       'aac',
-      '-filter:v',
-      'scale=trunc(oh*a/2)*2:1080',
+      '-filter_complex',
+      'scale=ceil(iw*min(1\\,min(1920/iw\\,1080/ih))/2)*2:-1',
       `${env.DATA_DIR}/uploads/${newId}.mp4`,
     ]);
     videoTranscodingProcess.once('details', (details: IFFMpegFileDetails) => {


### PR DESCRIPTION
This would allow videos that are wider than 1920px or taller than 1080px to be scaled down.
If the video is less 1920x1080 it's resolution will remain intact.
Aspect ratio is also persevered so if you upload a vertical video it should remain the correct size.
It also accounts for videos with resolutions that are not divisible by 2 so odd resolution/ratios should also remain intact.

Edit:
I used [this answer](https://superuser.com/a/794924) on superuser for reference.