### PR TITLE
suppress views/timestamp errors

### DIFF
--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -155,10 +155,12 @@ const VideoCard = ({ video }: { video: VideoInclude }) => {
               {video.progress ? (
                 'Processing...'
               ) : (
-                <span>
+                <span suppressHydrationWarning>
                   {`${video.views} Views • `}
-                  <Tooltip title={longCreatedAt}>
-                    <span>{`${shortCreatedAt} ago`}</span>
+                  <Tooltip title={longCreatedAt} suppressHydrationWarning>
+                    <span
+                      suppressHydrationWarning
+                    >{`${shortCreatedAt} ago`}</span>
                   </Tooltip>
                 </span>
               )}

--- a/src/pages/[id].tsx
+++ b/src/pages/[id].tsx
@@ -102,10 +102,12 @@ const VideoPage = ({
               title={video.title}
               titleTypographyProps={{ noWrap: true }}
               subheader={
-                <span>
+                <span suppressHydrationWarning>
                   {`${video.views} Views • `}
-                  <Tooltip title={longCreatedAt}>
-                    <span>{`${shortCreatedAt} ago`}</span>
+                  <Tooltip title={longCreatedAt} suppressHydrationWarning>
+                    <span
+                      suppressHydrationWarning
+                    >{`${shortCreatedAt} ago`}</span>
                   </Tooltip>
                 </span>
               }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -35,7 +35,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       session,
       videos: (videos || []).map((video) => ({
         ...video,
-        createdAt: video.createdAt.toLocaleString(),
+        createdAt: video.createdAt.toISOString(),
       })),
     },
   };


### PR DESCRIPTION
Fixes #10. Viewcount and timestamps are different server vs client. These aren't super important to be 100% accurate, so this will suppress those hydration errors.