### PR TITLE
add registry buildcache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,3 +30,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: samfry13/clippy:latest
+          cache-from: type=registry,ref=samfry13/clippy:buildcache
+          cache-to: type=registry,ref=samfry13/clippy:buildcache,mode=max


### PR DESCRIPTION
Adds a step to the build process to push a cache to the repository, which will then be used in subsequent image builds.