### PR TITLE
use react query dehydration

### DIFF
--- a/src/components/Upload.tsx
+++ b/src/components/Upload.tsx
@@ -1,9 +1,8 @@
-import { Fab, Snackbar } from '@mui/material';
+import { Fab } from '@mui/material';
 import { Upload as UploadIcon } from '@mui/icons-material';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import useUploadForm from '../utils/useUploadForm';
 import { useQueryClient } from 'react-query';
-import { useSession } from 'next-auth/react';
 import { useSnackbar } from 'notistack';
 
 const Upload = ({
@@ -12,7 +11,6 @@ const Upload = ({
   setUploadingVideos: (files: { file: File; progress: number }[]) => void;
 }) => {
   const input = useRef<HTMLInputElement>(null);
-  const { data: session } = useSession();
   const { enqueueSnackbar } = useSnackbar();
   const queryClient = useQueryClient();
   const { uploadFiles, files, progress } = useUploadForm(
@@ -21,7 +19,7 @@ const Upload = ({
       if (error) {
         enqueueSnackbar(`${error}`, { variant: 'error' });
       } else {
-        queryClient.invalidateQueries(['getAllVideos', session?.user?.id]);
+        queryClient.invalidateQueries(['getAllVideos']);
       }
     },
   );

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -21,7 +21,6 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { Close } from '@mui/icons-material';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
-import { useSession } from 'next-auth/react';
 import { VideoInclude } from '../utils/useUploadForm';
 import { format, formatDistanceToNow } from 'date-fns';
 import CardProgress from './CardProgress';
@@ -40,7 +39,6 @@ const StyledTextField = styled(TextField)({
 });
 
 const VideoCard = ({ video }: { video: VideoInclude }) => {
-  const { data: session } = useSession();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const open = Boolean(anchorEl);
   const { enqueueSnackbar } = useSnackbar();
@@ -59,7 +57,7 @@ const VideoCard = ({ video }: { video: VideoInclude }) => {
     },
     {
       onSuccess: () => {
-        queryClient.invalidateQueries(['getAllVideos', session?.user?.id]);
+        queryClient.invalidateQueries(['getAllVideos']);
       },
     },
   );
@@ -87,7 +85,7 @@ const VideoCard = ({ video }: { video: VideoInclude }) => {
       onError: (err: AxiosError) => {
         if (err.response?.status === 404) {
           setProgress(undefined);
-          queryClient.invalidateQueries(['getAllVideos', session?.user?.id]);
+          queryClient.invalidateQueries(['getAllVideos']);
         }
       },
     },

--- a/src/pages/[id].tsx
+++ b/src/pages/[id].tsx
@@ -104,10 +104,8 @@ const VideoPage = ({
               subheader={
                 <span suppressHydrationWarning>
                   {`${video.views} Views • `}
-                  <Tooltip title={longCreatedAt} suppressHydrationWarning>
-                    <span
-                      suppressHydrationWarning
-                    >{`${shortCreatedAt} ago`}</span>
+                  <Tooltip title={longCreatedAt}>
+                    <span>{`${shortCreatedAt} ago`}</span>
                   </Tooltip>
                 </span>
               }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,12 +2,11 @@
 import type { AppType } from 'next/dist/shared/lib/utils';
 import { SessionProvider } from 'next-auth/react';
 import '../styles/global.css';
-import { QueryClient, QueryClientProvider } from 'react-query';
+import { Hydrate, QueryClient, QueryClientProvider } from 'react-query';
 import { SnackbarProvider } from 'notistack';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { CssBaseline } from '@mui/material';
-
-const queryClient = new QueryClient();
+import { useState } from 'react';
 
 const darkTheme = createTheme({
   palette: {
@@ -17,17 +16,21 @@ const darkTheme = createTheme({
 
 const MyApp: AppType = ({
   Component,
-  pageProps: { session, ...pageProps },
+  pageProps: { session, dehydratedState, ...pageProps },
 }) => {
+  const [queryClient] = useState(() => new QueryClient());
+
   return (
     <SessionProvider session={session}>
       <QueryClientProvider client={queryClient}>
-        <ThemeProvider theme={darkTheme}>
-          <SnackbarProvider autoHideDuration={2000}>
-            <CssBaseline />
-            <Component {...pageProps} />
-          </SnackbarProvider>
-        </ThemeProvider>
+        <Hydrate state={dehydratedState}>
+          <ThemeProvider theme={darkTheme}>
+            <SnackbarProvider autoHideDuration={2000}>
+              <CssBaseline />
+              <Component {...pageProps} />
+            </SnackbarProvider>
+          </ThemeProvider>
+        </Hydrate>
       </QueryClientProvider>
     </SessionProvider>
   );

--- a/src/pages/api/videos/getAllForUser.ts
+++ b/src/pages/api/videos/getAllForUser.ts
@@ -12,16 +12,9 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     });
   }
 
-  if (session.user.id !== req.query.userId) {
-    return res.status(403).json({
-      message: 'You cannot access another users uploads',
-      success: false,
-    });
-  }
-
   return res.json(
     await getAllUsersVideos({
-      userId: req.query.userId,
+      userId: session.user.id,
       limit: req.query.limit ? Number(req.query.limit) : undefined,
       start: req.query.start ? Number(req.query.start) : undefined,
     }),


### PR DESCRIPTION
This uses react query's dehydrate/rehydrate strategy outlined [here](https://tanstack.com/query/v4/docs/guides/ssr#using-hydration). For some reason there was a discrepancy between the query client cache on the server vs client, and it was causing the server to render with 1 video instead of 2 after a video had been uploaded. Or 2 videos instead of 1 when a video had been deleted.

This should _really_ fix #10. For real this time.