### PR TITLE
fix: only allow video uploads

### DIFF
--- a/src/components/Upload.tsx
+++ b/src/components/Upload.tsx
@@ -40,6 +40,7 @@ const Upload = ({
         multiple
         style={{ display: 'none' }}
         ref={input}
+        accept="video/*"
         onChange={(e) => {
           uploadFiles([...Array.from(e.target.files || [])]);
           if (input.current) {

--- a/src/pages/api/videos/upload.ts
+++ b/src/pages/api/videos/upload.ts
@@ -38,8 +38,15 @@ upload.use(parser.single('video_file'));
 upload.post(async (req: MulterRequest, res) => {
   const session = await getServerSession(req, res, nextAuthOptions);
   if (!session?.user) {
-    return res.send({
+    return res.status(403).send({
       message: 'You must be signed in to upload a uploads',
+      success: false,
+    });
+  }
+
+  if (!req.file.mimetype.startsWith('video')) {
+    return res.status(400).send({
+      message: 'Only video files are allowed',
       success: false,
     });
   }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,7 +6,6 @@ import { authOptions } from './api/auth/[...nextauth]';
 import { signIn, useSession } from 'next-auth/react';
 import { useEffect, useState } from 'react';
 import VideoCard from '../components/VideoCard';
-import { Video } from '@prisma/client';
 import { Container, Grid } from '@mui/material';
 import { getAllUsersVideos } from '../server/db/videos';
 import { useQuery, QueryClient, dehydrate } from 'react-query';

--- a/src/utils/useUploadForm.ts
+++ b/src/utils/useUploadForm.ts
@@ -41,6 +41,9 @@ const useUploadForm = (url: string, callback: Callback<VideoInclude>) => {
           if (file.size > env.NEXT_PUBLIC_MAX_UPLOAD_SIZE) {
             throw new Error(`Filesize too large - ${file.name}`);
           }
+          if (!file.type.startsWith('video')) {
+            throw new Error('Only video files are allowed');
+          }
 
           const formData = new FormData();
           formData.append('video_file', file);


### PR DESCRIPTION
Should fix #22. Now verifying video file types on the input itself, on the client side before the upload (because users can click "all files" in the dialog if they really want to), and on the server as well, _just_ in case someone decides to hit the API directly.