### PR TITLE
gracefully handle ffmpeg video errors

### DIFF
--- a/src/utils/deleteFile.ts
+++ b/src/utils/deleteFile.ts
@@ -1,0 +1,7 @@
+import fs from 'fs';
+
+export const deleteFile = (path: string) => {
+  if (fs.existsSync(path)) {
+    fs.unlinkSync(path);
+  }
+};


### PR DESCRIPTION
Should fix #23. This adds a catch on the ffmpeg process to then delete the video and any progress if it errors out.

With this, however, the client won't know what happened, only that the uploaded video now disappears.